### PR TITLE
Add Kubernetes deployment skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # EXBanka-3-Infrastructure
+
+Infrastructure support repository for EXBanka.
+
+The Kubernetes deployment skeleton is in:
+
+- [deploy/k8s/base](deploy/k8s/base)
+
+Start there for the current K8s rollout baseline.

--- a/deploy/k8s/base/README.md
+++ b/deploy/k8s/base/README.md
@@ -1,0 +1,95 @@
+# EXBanka Kubernetes base skeleton
+
+This folder contains the first Kubernetes deployment skeleton for EXBanka.
+
+It is intentionally limited to the application layer shape:
+
+- namespaces
+- shared app ConfigMap
+- Secret example
+- one Deployment and Service per existing application service
+- dev Mailhog Deployment and Service
+- Ingress route map translated from the current frontend `nginx.conf`
+
+It does not deploy PostgreSQL, Redis, CloudNativePG, real secrets, or production observability.
+
+## Layout
+
+```text
+deploy/k8s/base/
+  kustomization.yaml
+  namespaces.yaml
+  app-config.yaml
+  app-secret.example.yaml
+  deployments.yaml
+  services.yaml
+  ingress.yaml
+  mailhog.yaml
+```
+
+## Prerequisites
+
+- Kubernetes cluster
+- `kubectl`
+- nginx Ingress controller if applying `ingress.yaml`
+- Image registry with built EXBanka service images
+- PostgreSQL layer from the next PR before the application pods can become fully ready
+
+## Secrets
+
+Do not commit real secret values.
+
+Create the app secret manually from secure values:
+
+```powershell
+kubectl create secret generic exbanka-app-secrets `
+  --namespace exbanka `
+  --from-literal=DB_USER=postgres `
+  --from-literal=DB_PASSWORD='<replace-me>' `
+  --from-literal=JWT_SECRET='<replace-me>' `
+  --from-literal=ALPHA_VANTAGE_KEY='<replace-me>' `
+  --from-literal=REDIS_PASSWORD='<replace-me>'
+```
+
+`app-secret.example.yaml` exists only as a shape reference.
+
+## Validate locally
+
+Render the base:
+
+```powershell
+kubectl kustomize .\deploy\k8s\base
+```
+
+Dry-run the rendered manifests:
+
+```powershell
+kubectl apply --dry-run=client -k .\deploy\k8s\base
+```
+
+## Apply order
+
+For the full project rollout, use this order:
+
+1. Apply this Kubernetes base skeleton.
+2. Apply PostgreSQL/CloudNativePG from the Postgres replication PR.
+3. Apply Redis from the Redis PR.
+4. Build and push application images with immutable tags.
+5. Replace `replace-with-git-sha` image tags with actual image tags or Kustomize overlays.
+6. Apply app manifests and verify Ingress routes.
+
+## Scaling rule
+
+Keep these services at one replica until cron leadership is implemented:
+
+- `exchange-service`
+- `loan-service`
+
+Both services own scheduled jobs today. Scaling them before leader election can run the same job multiple times.
+
+## Current limitations
+
+- The base points `DB_HOST` to the future CloudNativePG read/write endpoint `bankdb-rw.exbanka-db.svc.cluster.local`.
+- Application pods are not expected to become fully ready until the Postgres PR is applied.
+- Redis values are reserved in the Secret example, but Redis is not deployed in this PR.
+- This skeleton uses raw Kubernetes plus Kustomize because it is easy to validate with the currently available local tooling.

--- a/deploy/k8s/base/app-config.yaml
+++ b/deploy/k8s/base/app-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exbanka-app-config
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/part-of: exbanka
+data:
+  DB_HOST: bankdb-rw.exbanka-db.svc.cluster.local
+  DB_PORT: "5432"
+  DB_NAME: bankdb
+  DB_SSL_MODE: disable
+  JWT_ACCESS_DURATION_MINUTES: "15"
+  JWT_REFRESH_DURATION_HOURS: "24"
+  SMTP_HOST: mailhog
+  SMTP_PORT: "1025"
+  SMTP_FROM: noreply@bank.com
+  FRONTEND_URL: http://exbanka.local

--- a/deploy/k8s/base/app-secret.example.yaml
+++ b/deploy/k8s/base/app-secret.example.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: exbanka-app-secrets
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/part-of: exbanka
+type: Opaque
+stringData:
+  DB_USER: postgres
+  DB_PASSWORD: change-me
+  JWT_SECRET: change-me
+  ALPHA_VANTAGE_KEY: change-me
+  REDIS_PASSWORD: change-me

--- a/deploy/k8s/base/deployments.yaml
+++ b/deploy/k8s/base/deployments.yaml
@@ -1,0 +1,563 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/dt30f/exbanka-3-backend/backend:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: grpc
+              containerPort: 9090
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8080"
+            - name: GRPC_PORT
+              value: "9090"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: auth-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: auth-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: auth-service
+          image: ghcr.io/dt30f/exbanka-3-backend/auth-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8081
+            - name: grpc
+              containerPort: 9091
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8081"
+            - name: GRPC_PORT
+              value: "9091"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: employee-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: employee-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: employee-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: employee-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: employee-service
+          image: ghcr.io/dt30f/exbanka-3-backend/employee-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8082
+            - name: grpc
+              containerPort: 9092
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8082"
+            - name: GRPC_PORT
+              value: "9092"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: client-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: client-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: client-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: client-service
+          image: ghcr.io/dt30f/exbanka-3-backend/client-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8083
+            - name: grpc
+              containerPort: 9093
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8083"
+            - name: GRPC_PORT
+              value: "9093"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: account-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: account-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: account-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: account-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: account-service
+          image: ghcr.io/dt30f/exbanka-3-backend/account-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8084
+            - name: grpc
+              containerPort: 9094
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8084"
+            - name: GRPC_PORT
+              value: "9094"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transfer-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: transfer-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: transfer-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: transfer-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: transfer-service
+          image: ghcr.io/dt30f/exbanka-3-backend/transfer-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8086
+            - name: grpc
+              containerPort: 9096
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8086"
+            - name: GRPC_PORT
+              value: "9096"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: payment-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: payment-service
+          image: ghcr.io/dt30f/exbanka-3-backend/payment-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8087
+            - name: grpc
+              containerPort: 9097
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8087"
+            - name: GRPC_PORT
+              value: "9097"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exchange-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: exchange-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: exchange-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: exchange-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: exchange-service
+          image: ghcr.io/dt30f/exbanka-3-backend/exchange-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8088
+            - name: grpc
+              containerPort: 9098
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8088"
+            - name: GRPC_PORT
+              value: "9098"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loan-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: loan-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loan-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loan-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: loan-service
+          image: ghcr.io/dt30f/exbanka-3-backend/loan-service:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8089
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8089"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/dt30f/exbanka-3-frontend/frontend:replace-with-git-sha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/deploy/k8s/base/ingress.yaml
+++ b/deploy/k8s/base/ingress.yaml
@@ -1,0 +1,212 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: exbanka
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: exbanka
+    app.kubernetes.io/part-of: exbanka
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: exbanka.local
+      http:
+        paths:
+          - path: /api/v1/auth/
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  name: http
+          - path: /api/v1/permissions
+            pathType: Exact
+            backend:
+              service:
+                name: employee-service
+                port:
+                  name: http
+          - path: /api/v1/employees
+            pathType: Prefix
+            backend:
+              service:
+                name: employee-service
+                port:
+                  name: http
+          - path: /api/v1/actuaries
+            pathType: Prefix
+            backend:
+              service:
+                name: employee-service
+                port:
+                  name: http
+          - path: /api/v1/clients
+            pathType: Prefix
+            backend:
+              service:
+                name: client-service
+                port:
+                  name: http
+          - path: /api/v1/firme
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/sifre-delatnosti
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/currencies
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/accounts/create
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/accounts
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/cards
+            pathType: Prefix
+            backend:
+              service:
+                name: account-service
+                port:
+                  name: http
+          - path: /api/v1/transfers
+            pathType: Prefix
+            backend:
+              service:
+                name: transfer-service
+                port:
+                  name: http
+          - path: /api/v1/payments
+            pathType: Prefix
+            backend:
+              service:
+                name: payment-service
+                port:
+                  name: http
+          - path: /api/v1/prenos
+            pathType: Prefix
+            backend:
+              service:
+                name: payment-service
+                port:
+                  name: http
+          - path: /api/v1/recipients
+            pathType: Prefix
+            backend:
+              service:
+                name: payment-service
+                port:
+                  name: http
+          - path: /api/v1/exchanges
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/listings
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/portfolio
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/exchange
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/orders
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/tax
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/otc
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/interbank-otc
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/funds
+            pathType: Prefix
+            backend:
+              service:
+                name: exchange-service
+                port:
+                  name: http
+          - path: /api/v1/loans
+            pathType: Prefix
+            backend:
+              service:
+                name: loan-service
+                port:
+                  name: http
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  name: http
+          - path: /swagger
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - app-config.yaml
+  - deployments.yaml
+  - services.yaml
+  - ingress.yaml
+  - mailhog.yaml

--- a/deploy/k8s/base/mailhog.yaml
+++ b/deploy/k8s/base/mailhog.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailhog
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: mailhog
+    app.kubernetes.io/part-of: exbanka
+    app.kubernetes.io/component: dev-smtp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailhog
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mailhog
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: mailhog
+          image: mailhog/mailhog:v1.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: smtp
+              containerPort: 1025
+            - name: web
+              containerPort: 8025
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailhog
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: mailhog
+    app.kubernetes.io/part-of: exbanka
+    app.kubernetes.io/component: dev-smtp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mailhog
+  ports:
+    - name: smtp
+      port: 1025
+      targetPort: smtp
+    - name: web
+      port: 8025
+      targetPort: web

--- a/deploy/k8s/base/namespaces.yaml
+++ b/deploy/k8s/base/namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: exbanka
+  labels:
+    app.kubernetes.io/part-of: exbanka
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: exbanka-db
+  labels:
+    app.kubernetes.io/part-of: exbanka

--- a/deploy/k8s/base/services.yaml
+++ b/deploy/k8s/base/services.yaml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: grpc
+      port: 9090
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: auth-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: auth-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+    - name: grpc
+      port: 9091
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: employee-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: employee-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: employee-service
+  ports:
+    - name: http
+      port: 8082
+      targetPort: http
+    - name: grpc
+      port: 9092
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: client-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: client-service
+  ports:
+    - name: http
+      port: 8083
+      targetPort: http
+    - name: grpc
+      port: 9093
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: account-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: account-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: account-service
+  ports:
+    - name: http
+      port: 8084
+      targetPort: http
+    - name: grpc
+      port: 9094
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: transfer-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: transfer-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: transfer-service
+  ports:
+    - name: http
+      port: 8086
+      targetPort: http
+    - name: grpc
+      port: 9096
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: payment-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: payment-service
+  ports:
+    - name: http
+      port: 8087
+      targetPort: http
+    - name: grpc
+      port: 9097
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: exchange-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: exchange-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: exchange-service
+  ports:
+    - name: http
+      port: 8088
+      targetPort: http
+    - name: grpc
+      port: 9098
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loan-service
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: loan-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: loan-service
+  ports:
+    - name: http
+      port: 8089
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## Summary
- Adds the base Kubernetes/Kustomize deployment skeleton for the EXBanka stack.
- Defines namespaces, ConfigMap, Secret example, Deployments, Services, Mailhog, and Ingress routing.
- Keeps Postgres replication, Redis, and application logic changes out of scope.

## Testing
- `kubectl kustomize .\deploy\k8s\base`

## Notes
- Real secrets are not committed.
- Application pods depend on the follow-up Postgres/CloudNativePG PR before full runtime readiness.