### PR TITLE
Add CloudNativePG PostgreSQL replication foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ The Kubernetes deployment skeleton is in:
 
 - [deploy/k8s/base](deploy/k8s/base)
 
+The CloudNativePG PostgreSQL foundation is in:
+
+- [deploy/postgres](deploy/postgres)
+
 Start there for the current K8s rollout baseline.

--- a/deploy/k8s/base/README.md
+++ b/deploy/k8s/base/README.md
@@ -44,7 +44,7 @@ Create the app secret manually from secure values:
 ```powershell
 kubectl create secret generic exbanka-app-secrets `
   --namespace exbanka `
-  --from-literal=DB_USER=postgres `
+  --from-literal=DB_USER=exbanka_app `
   --from-literal=DB_PASSWORD='<replace-me>' `
   --from-literal=JWT_SECRET='<replace-me>' `
   --from-literal=ALPHA_VANTAGE_KEY='<replace-me>' `
@@ -52,6 +52,9 @@ kubectl create secret generic exbanka-app-secrets `
 ```
 
 `app-secret.example.yaml` exists only as a shape reference.
+
+The `DB_USER` and `DB_PASSWORD` values must match the Postgres credentials created
+for CloudNativePG in the `exbanka-db` namespace.
 
 ## Validate locally
 

--- a/deploy/k8s/base/app-config.yaml
+++ b/deploy/k8s/base/app-config.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: exbanka
 data:
-  DB_HOST: bankdb-rw.exbanka-db.svc.cluster.local
+  DB_HOST: exbanka-postgres-rw.exbanka-db.svc.cluster.local
   DB_PORT: "5432"
   DB_NAME: bankdb
   DB_SSL_MODE: disable

--- a/deploy/k8s/base/app-secret.example.yaml
+++ b/deploy/k8s/base/app-secret.example.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: exbanka
 type: Opaque
 stringData:
-  DB_USER: postgres
+  DB_USER: exbanka_app
   DB_PASSWORD: change-me
   JWT_SECRET: change-me
   ALPHA_VANTAGE_KEY: change-me

--- a/deploy/postgres/README.md
+++ b/deploy/postgres/README.md
@@ -1,0 +1,122 @@
+# EXBanka PostgreSQL replication foundation
+
+This folder contains the CloudNativePG foundation for the shared EXBanka PostgreSQL database.
+
+It creates one logical database cluster:
+
+- cluster name: `exbanka-postgres`
+- database: `bankdb`
+- namespace: `exbanka-db`
+- instances: `2`
+- topology: one primary plus one hot standby
+- synchronization target: one standby
+
+All EXBanka services still use one database, `bankdb`. This PR does not split the database per service and does not add application-level read/write routing.
+
+## Prerequisites
+
+- Kubernetes cluster
+- `kubectl`
+- CloudNativePG operator installed
+- `exbanka-db` namespace from `deploy/k8s/base/namespaces.yaml`
+- StorageClass that supports `ReadWriteOnce`
+
+Install the CloudNativePG operator before applying this folder. Use the official installation method for the version selected by the team.
+
+## Secrets
+
+Do not commit real database credentials.
+
+Create the database secret manually:
+
+```powershell
+kubectl create secret generic bankdb-credentials `
+  --namespace exbanka-db `
+  --type=kubernetes.io/basic-auth `
+  --from-literal=username=exbanka_app `
+  --from-literal=password='<replace-me>'
+```
+
+`bankdb-secret.example.yaml` documents the required shape only.
+
+Because Kubernetes secrets are namespace-scoped, the application namespace still needs
+`exbanka-app-secrets` with matching `DB_USER` and `DB_PASSWORD` values. Keep the
+database credentials in `exbanka-db/bankdb-credentials` and
+`exbanka/exbanka-app-secrets` synchronized until an external secret sync mechanism is
+introduced.
+
+## Apply
+
+Render manifests:
+
+```powershell
+kubectl kustomize .\deploy\postgres
+```
+
+Apply after the CloudNativePG operator is installed:
+
+```powershell
+kubectl apply -k .\deploy\postgres
+```
+
+## Verify readiness
+
+```powershell
+kubectl get cluster -n exbanka-db
+kubectl get pods -n exbanka-db
+kubectl get svc -n exbanka-db
+```
+
+CloudNativePG creates stable services similar to:
+
+- `exbanka-postgres-rw` for the current primary
+- `exbanka-postgres-ro` for read-only replicas
+- `exbanka-postgres-r` for all Postgres instances
+
+The application base config points `DB_HOST` at:
+
+```text
+exbanka-postgres-rw.exbanka-db.svc.cluster.local
+```
+
+That is intentional. Until repository-level read routing is reviewed, all services should keep using the primary endpoint.
+
+## Primary/standby check
+
+Run on each Postgres pod:
+
+```powershell
+kubectl exec -n exbanka-db <postgres-pod> -- `
+  psql -U exbanka_app -d bankdb -c "select pg_is_in_recovery();"
+```
+
+Expected:
+
+- one pod returns `false` and is the primary
+- one pod returns `true` and is the standby
+
+## Basic failover smoke
+
+Delete the current primary pod:
+
+```powershell
+kubectl delete pod -n exbanka-db <primary-pod>
+kubectl get pods -n exbanka-db -w
+```
+
+Expected:
+
+- standby is promoted automatically
+- `exbanka-postgres-rw` follows the new primary
+- cluster returns to a healthy state
+
+## Out of scope
+
+- Redis
+- GORM `dbresolver`
+- `DB_READ_HOST`
+- read/write split in application code
+- WAL archival / PITR object store
+- multi-region disaster recovery
+
+WAL archival and PITR should be added as a follow-up once the team chooses MinIO/S3-compatible storage.

--- a/deploy/postgres/bankdb-secret.example.yaml
+++ b/deploy/postgres/bankdb-secret.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bankdb-credentials
+  namespace: exbanka-db
+  labels:
+    app.kubernetes.io/name: exbanka-postgres
+    app.kubernetes.io/part-of: exbanka
+type: kubernetes.io/basic-auth
+stringData:
+  username: exbanka_app
+  password: change-me

--- a/deploy/postgres/cloudnativepg-cluster.yaml
+++ b/deploy/postgres/cloudnativepg-cluster.yaml
@@ -1,0 +1,32 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: exbanka-postgres
+  namespace: exbanka-db
+  labels:
+    app.kubernetes.io/name: exbanka-postgres
+    app.kubernetes.io/part-of: exbanka
+spec:
+  instances: 2
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:15
+
+  bootstrap:
+    initdb:
+      database: bankdb
+      owner: exbanka_app
+      secret:
+        name: bankdb-credentials
+
+  storage:
+    size: 20Gi
+
+  postgresql:
+    parameters:
+      synchronous_commit: "on"
+
+  minSyncReplicas: 1
+  maxSyncReplicas: 1
+
+  monitoring:
+    enablePodMonitor: false

--- a/deploy/postgres/kustomization.yaml
+++ b/deploy/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cloudnativepg-cluster.yaml


### PR DESCRIPTION
## Summary
- Adds the CloudNativePG PostgreSQL foundation for the shared `bankdb` database.
- Defines a two-instance Postgres cluster with primary/standby replication.
- Points the Kubernetes app config at the stable `exbanka-postgres-rw` endpoint.

## Testing
- `kubectl kustomize .\deploy\postgres`
- `kubectl kustomize .\deploy\k8s\base`
- Verified the CloudNativePG PostgreSQL image tag exists.

## Notes
- Real secrets are not committed.
- This does not add Redis.
- This does not add application-level read/write split.