### PR TITLE
Add Redis deployment foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,8 @@ The CloudNativePG PostgreSQL foundation is in:
 
 - [deploy/postgres](deploy/postgres)
 
+The Redis deployment foundation is in:
+
+- [deploy/redis](deploy/redis)
+
 Start there for the current K8s rollout baseline.

--- a/deploy/k8s/base/README.md
+++ b/deploy/k8s/base/README.md
@@ -56,6 +56,9 @@ kubectl create secret generic exbanka-app-secrets `
 The `DB_USER` and `DB_PASSWORD` values must match the Postgres credentials created
 for CloudNativePG in the `exbanka-db` namespace.
 
+`REDIS_PASSWORD` must match the Redis credentials created from
+`deploy/redis/redis-secret.example.yaml`.
+
 ## Validate locally
 
 Render the base:

--- a/deploy/k8s/base/app-config.yaml
+++ b/deploy/k8s/base/app-config.yaml
@@ -16,3 +16,5 @@ data:
   SMTP_PORT: "1025"
   SMTP_FROM: noreply@bank.com
   FRONTEND_URL: http://exbanka.local
+  REDIS_ADDR: exbanka-redis-master.exbanka.svc.cluster.local:6379
+  REDIS_DB: "0"

--- a/deploy/redis/README.md
+++ b/deploy/redis/README.md
@@ -1,0 +1,135 @@
+# EXBanka Redis deployment foundation
+
+This folder contains the Kubernetes Redis deployment foundation for EXBanka.
+
+Redis is introduced as shared cross-instance state for cache and coordination use
+cases. It is not the system of record. Money, account balances, SAGA state, and
+durable interbank state remain in PostgreSQL.
+
+## Scope
+
+This PR adds Redis infrastructure only:
+
+- Bitnami Redis Helm values
+- Redis authentication via a Kubernetes Secret
+- master plus one replica topology
+- application ConfigMap placeholders for `REDIS_ADDR` and `REDIS_DB`
+- rollout and verification documentation
+
+It does not add backend Redis clients, token revocation, FX cache replacement, rate
+limiting, or cron leadership.
+
+## Prerequisites
+
+- Kubernetes cluster
+- `kubectl`
+- Helm
+- `exbanka` namespace from `deploy/k8s/base/namespaces.yaml`
+- Bitnami Helm repository
+
+Add the Bitnami repository:
+
+```powershell
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+```
+
+## Secret
+
+Do not commit real Redis credentials.
+
+Create the Redis secret manually:
+
+```powershell
+kubectl create secret generic redis-credentials `
+  --namespace exbanka `
+  --from-literal=redis-password='<replace-me>'
+```
+
+`redis-secret.example.yaml` documents the expected shape only.
+
+The app namespace secret `exbanka-app-secrets` also contains `REDIS_PASSWORD`.
+Keep that value synchronized with `redis-credentials` until an external secret sync
+mechanism is introduced.
+
+## Install
+
+Install Redis with a stable release name:
+
+```powershell
+helm upgrade --install exbanka-redis bitnami/redis `
+  --namespace exbanka `
+  --values .\deploy\redis\values.yaml
+```
+
+The current public Bitnami chart may emit a rolling-image warning depending on the
+available free image catalog. Treat that as a production hardening follow-up: pin a
+team-approved Redis image tag or digest before a real production rollout.
+
+The application ConfigMap points `REDIS_ADDR` at:
+
+```text
+exbanka-redis-master.exbanka.svc.cluster.local:6379
+```
+
+This keeps all initial Redis traffic on the master. Read-from-replica can be added
+later if metrics justify it.
+
+## Verify
+
+Check Redis pods and services:
+
+```powershell
+kubectl get pods -n exbanka -l app.kubernetes.io/instance=exbanka-redis
+kubectl get svc -n exbanka -l app.kubernetes.io/instance=exbanka-redis
+```
+
+Expected services include:
+
+- `exbanka-redis-master`
+- `exbanka-redis-replicas`
+- `exbanka-redis-headless`
+
+Smoke test with the stored password:
+
+```powershell
+$redisPassword = kubectl get secret redis-credentials `
+  -n exbanka `
+  -o jsonpath="{.data.redis-password}"
+$redisPassword = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($redisPassword))
+
+kubectl run redis-client `
+  --namespace exbanka `
+  --rm `
+  --tty `
+  -i `
+  --restart='Never' `
+  --image docker.io/bitnami/redis:7.4 `
+  --env REDISCLI_AUTH=$redisPassword `
+  -- redis-cli -h exbanka-redis-master ping
+```
+
+Expected output:
+
+```text
+PONG
+```
+
+## Failure model
+
+Consumers must treat Redis as cache/coordination only:
+
+- Redis outage must not crash services.
+- Auth revocation checks should fail open and log loudly.
+- FX cache should fall back to the current provider path.
+- AlphaVantage rate limiting should fall back to the local limiter.
+- No money or durable workflow state may be stored in Redis.
+
+## Follow-up work
+
+Next PRs should add backend integration gradually:
+
+1. `auth-service`: Redis-backed token revocation list.
+2. `exchange-service`: shared FX-rate cache.
+3. `exchange-service`: distributed AlphaVantage rate limiter.
+4. Cron leadership only after the team chooses Redis lock vs Kubernetes Lease.

--- a/deploy/redis/redis-secret.example.yaml
+++ b/deploy/redis/redis-secret.example.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: exbanka
+  labels:
+    app.kubernetes.io/name: exbanka-redis
+    app.kubernetes.io/part-of: exbanka
+type: Opaque
+stringData:
+  redis-password: change-me

--- a/deploy/redis/values.yaml
+++ b/deploy/redis/values.yaml
@@ -1,0 +1,46 @@
+architecture: replication
+
+commonConfiguration: |-
+  appendonly yes
+  appendfsync everysec
+  save ""
+
+auth:
+  enabled: true
+  existingSecret: redis-credentials
+  existingSecretPasswordKey: redis-password
+
+master:
+  count: 1
+  persistence:
+    enabled: true
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+replica:
+  replicaCount: 1
+  persistence:
+    enabled: true
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+commonLabels:
+  app.kubernetes.io/part-of: exbanka
+
+metrics:
+  enabled: false
+
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
## Summary
- Adds the Kubernetes Redis deployment foundation for EXBanka.
- Adds Bitnami Redis Helm values for master/replica deployment.
- Adds Redis secret example and rollout documentation.
- Adds Redis connection placeholders to the shared app ConfigMap.

## Details
- Configures Redis with authentication, persistence, and AOF enabled.
- Uses `exbanka-redis-master` as the initial application endpoint.
- Documents secret creation, Helm install, service verification, and `PING` smoke test.
- Keeps backend Redis client integration out of scope for this PR.

## Testing
- `kubectl kustomize .\deploy\k8s\base`
- `helm template exbanka-redis bitnami/redis --namespace exbanka --values .\deploy\redis\values.yaml`
- Live Docker Desktop Kubernetes smoke test:
  - Redis master and replica pods are running
  - `redis-cli PING` returns `PONG`

## Notes
- Real Redis credentials are not committed.
- This PR does not add token revocation, FX cache, rate limiting, or cron leader locking.
- Application-level Redis integration will be handled in follow-up PRs.