### PR TITLE
Use readiness probes for backend services

### DIFF
--- a/deploy/k8s/base/README.md
+++ b/deploy/k8s/base/README.md
@@ -73,6 +73,15 @@ Dry-run the rendered manifests:
 kubectl apply --dry-run=client -k .\deploy\k8s\base
 ```
 
+## Health probes
+
+Go services use separate probe endpoints:
+
+- readiness probes call `/ready`, which checks PostgreSQL connectivity before a pod receives traffic.
+- liveness probes call `/health`, which stays lightweight and does not depend on PostgreSQL or Redis.
+
+The frontend keeps `/` for both probes because it only serves static assets/nginx routing.
+
 ## Apply order
 
 For the full project rollout, use this order:
@@ -95,7 +104,7 @@ Both services own scheduled jobs today. Scaling them before leader election can 
 
 ## Current limitations
 
-- The base points `DB_HOST` to the future CloudNativePG read/write endpoint `bankdb-rw.exbanka-db.svc.cluster.local`.
+- The base points `DB_HOST` to the CloudNativePG read/write endpoint `exbanka-postgres-rw.exbanka-db.svc.cluster.local`.
 - Application pods are not expected to become fully ready until the Postgres PR is applied.
-- Redis values are reserved in the Secret example, but Redis is not deployed in this PR.
+- Redis values are reserved in the Secret example and consumed by Redis-aware services, but Redis is not a hard readiness dependency.
 - This skeleton uses raw Kubernetes plus Kustomize because it is easy to validate with the currently available local tooling.

--- a/deploy/k8s/base/deployments.yaml
+++ b/deploy/k8s/base/deployments.yaml
@@ -38,7 +38,7 @@ spec:
               value: "9090"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -96,7 +96,7 @@ spec:
               value: "9091"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -154,7 +154,7 @@ spec:
               value: "9092"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -212,7 +212,7 @@ spec:
               value: "9093"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -270,7 +270,7 @@ spec:
               value: "9094"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -328,7 +328,7 @@ spec:
               value: "9096"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -386,7 +386,7 @@ spec:
               value: "9097"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -444,7 +444,7 @@ spec:
               value: "9098"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -498,7 +498,7 @@ spec:
               value: "8089"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
## Summary
- Updates Kubernetes backend readiness probes to use `/ready`.
- Keeps liveness probes on `/health`.
- Documents probe behavior in the K8s base README.

## Details
- Backend pods only receive traffic after their `/ready` endpoint confirms PostgreSQL connectivity.
- Liveness remains lightweight and independent of PostgreSQL/Redis.
- Frontend probes stay on `/` because it is an nginx/static container.

## Testing
- kubectl kustomize .\deploy\k8s\base
- kubectl apply --dry-run=client -k .\deploy\k8s\base
- git diff --check