### PR TITLE
Document Redis auth revocation smoke

### DIFF
--- a/deploy/DEPLOYMENT_RUNBOOK.md
+++ b/deploy/DEPLOYMENT_RUNBOOK.md
@@ -343,9 +343,70 @@ Run these after pods are ready:
 - Exchange service `/ready` returns ready.
 - Loan service `/ready` returns ready.
 - Redis ping returns `PONG`.
+- Employee/admin logout revokes the current access token and refresh token.
 - PostgreSQL cluster has one primary and one standby.
 - No pod is in `CrashLoopBackOff`.
 - No app pod is stuck in `0/1 Ready`.
+
+### Auth token revocation smoke
+
+Run this after Redis and application pods are ready. Use a seeded employee/admin
+account for the target environment.
+
+```powershell
+$baseUrl = "http://exbanka.local"
+
+$login = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$baseUrl/api/v1/auth/login" `
+  -ContentType "application/json" `
+  -Body (@{
+    email = "<admin-email>"
+    password = "<admin-password>"
+  } | ConvertTo-Json)
+
+$headers = @{ Authorization = "Bearer $($login.accessToken)" }
+
+Invoke-RestMethod `
+  -Method Get `
+  -Uri "$baseUrl/api/v1/employees" `
+  -Headers $headers
+
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "$baseUrl/api/v1/auth/logout" `
+  -Headers $headers `
+  -ContentType "application/json" `
+  -Body (@{ refreshToken = $login.refreshToken } | ConvertTo-Json)
+
+try {
+  Invoke-WebRequest `
+    -Method Get `
+    -Uri "$baseUrl/api/v1/employees" `
+    -Headers $headers `
+    -UseBasicParsing
+} catch {
+  $_.Exception.Response.StatusCode.value__
+}
+
+try {
+  Invoke-WebRequest `
+    -Method Post `
+    -Uri "$baseUrl/api/v1/auth/refresh" `
+    -ContentType "application/json" `
+    -Body (@{ refreshToken = $login.refreshToken } | ConvertTo-Json) `
+    -UseBasicParsing
+} catch {
+  $_.Exception.Response.StatusCode.value__
+}
+```
+
+Expected result:
+
+- protected employee endpoint works before logout
+- logout returns `200`
+- reused access token returns `401`
+- reused refresh token returns `401`
 
 Useful commands:
 
@@ -429,7 +490,8 @@ Keep these limitations explicit:
 
 - `exchange-service` stays at one replica until cron leadership is implemented.
 - `loan-service` stays at one replica until cron leadership is implemented.
-- Redis-backed auth token revocation is not fully implemented yet.
+- Redis-backed auth token revocation is implemented, but Redis remains optional for
+  service readiness and checks fail open if Redis is unavailable.
 - Redis is not a system of record.
 - CloudNativePG WAL archival/PITR is not configured yet.
 - Image build/publish automation is still manual.

--- a/deploy/redis/README.md
+++ b/deploy/redis/README.md
@@ -8,7 +8,7 @@ durable interbank state remain in PostgreSQL.
 
 ## Scope
 
-This PR adds Redis infrastructure only:
+This folder provides the Redis deployment foundation:
 
 - Bitnami Redis Helm values
 - Redis authentication via a Kubernetes Secret
@@ -16,8 +16,12 @@ This PR adds Redis infrastructure only:
 - application ConfigMap placeholders for `REDIS_ADDR` and `REDIS_DB`
 - rollout and verification documentation
 
-It does not add backend Redis clients, token revocation, FX cache replacement, rate
-limiting, or cron leadership.
+Current backend usage:
+
+- auth token revocation for employee and client logout
+
+It does not make Redis a system of record and it does not yet add FX cache
+replacement, rate limiting, or cron leadership.
 
 ## Prerequisites
 
@@ -115,6 +119,37 @@ Expected output:
 PONG
 ```
 
+## Auth revocation smoke
+
+After application pods are rolled out with `REDIS_ADDR`, `REDIS_DB`, and
+`REDIS_PASSWORD`, verify that logout writes revocation entries and blocks token
+reuse:
+
+1. Login through `/api/v1/auth/login`.
+2. Call a protected endpoint with the returned access token and expect success.
+3. Call `/api/v1/auth/logout` with the access token and refresh token.
+4. Reuse the old access token and expect `401`.
+5. Reuse the old refresh token on `/api/v1/auth/refresh` and expect `401`.
+
+Optional Redis key check:
+
+```powershell
+$redisPassword = kubectl get secret redis-credentials `
+  -n exbanka `
+  -o jsonpath="{.data.redis-password}"
+$redisPassword = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($redisPassword))
+
+kubectl run redis-client `
+  --namespace exbanka `
+  --rm `
+  --tty `
+  -i `
+  --restart='Never' `
+  --image docker.io/bitnami/redis:7.4 `
+  --env REDISCLI_AUTH=$redisPassword `
+  -- redis-cli -h exbanka-redis-master keys "auth:revoked:jti:*"
+```
+
 ## Failure model
 
 Consumers must treat Redis as cache/coordination only:
@@ -129,7 +164,6 @@ Consumers must treat Redis as cache/coordination only:
 
 Next PRs should add backend integration gradually:
 
-1. `auth-service`: Redis-backed token revocation list.
-2. `exchange-service`: shared FX-rate cache.
-3. `exchange-service`: distributed AlphaVantage rate limiter.
-4. Cron leadership only after the team chooses Redis lock vs Kubernetes Lease.
+1. `exchange-service`: shared FX-rate cache.
+2. `exchange-service`: distributed AlphaVantage rate limiter.
+3. Cron leadership only after the team chooses Redis lock vs Kubernetes Lease.


### PR DESCRIPTION
## Summary
- Updates Redis deployment documentation to reflect implemented auth token revocation.
- Adds a deployment smoke procedure for login, logout, access-token revocation, and refresh-token revocation.
- Removes outdated notes that described auth revocation as future work.

## Testing
- Verified local Docker runtime with Redis enabled.
- Confirmed login succeeds before logout.
- Confirmed old access token returns 401 after logout.
- Confirmed old refresh token returns 401 after logout.
- Confirmed Redis contains auth revocation keys.