### PR TITLE
Route inter-bank protocol under the /exchange slug

### DIFF
--- a/deploy/k8s/base/app-secret.example.yaml
+++ b/deploy/k8s/base/app-secret.example.yaml
@@ -20,6 +20,14 @@ stringData:
   # PARTNER_BANKS_JSON is a JSON array of partner-bank entries. Contains per-
   # partner inbound/outbound API keys, so it lives in the Secret. Use "[]" for
   # no partners.
+  #
+  # `code` is the partner's 3-digit routing number as a JSON NUMBER (not a
+  # quoted string — RoutingNumber is a plain int and won't unmarshal a string).
+  # `baseUrl` is the partner's protocol BASE with NO trailing /interbank: the
+  # client appends /interbank, /negotiations, /public-stock, /user itself.
+  # `outboundKey` = the key the partner issued to us (we send it to them);
+  # `inboundKey`  = the key we issued to the partner (we require it from them).
+  # Two partners must not share the same inboundKey (registry refuses to load).
   # Example single-partner shape:
-  # [{"code":"222","baseUrl":"https://partner.example/interbank","outboundKey":"<sent-by-us>","inboundKey":"<expected-from-them>","displayName":"Partner Bank"}]
+  # [{"code":222,"baseUrl":"https://partner.example/api/v3/cross-bank-protocol","outboundKey":"<key-they-issued-to-us>","inboundKey":"<key-we-issued-to-them>","displayName":"Partner Bank"}]
   PARTNER_BANKS_JSON: "[]"

--- a/deploy/k8s/base/route.yaml
+++ b/deploy/k8s/base/route.yaml
@@ -108,6 +108,57 @@ spec:
       backendRefs:
         - name: backend
           port: 8080
+    # Inbound inter-bank protocol (si-tx-proto, Celina 5). Professor mandate:
+    # every externally-reachable URL is https://<domain>/<service-name>/... , so
+    # partner banks reach our protocol under the /exchange slug — the same
+    # service-name the frontend already uses for the OTC UI (/exchange/api/...).
+    #
+    # exchange-service mounts the protocol at ROOT (/interbank, /public-stock,
+    # /negotiations, /user/ — see cmd/server/main.go), so each rule strips the
+    # /exchange prefix back down to /<route> with ReplacePrefixMatch. We keep
+    # these as explicit per-route rules (rather than broadening /exchange/api to
+    # /exchange) so the working frontend rule is left untouched.
+    #
+    # PathPrefix matches per path element, so /exchange/interbank does NOT match
+    # the local UI route /exchange/api/v1/interbank-otc. The partner-facing base
+    # URL we hand out is therefore https://exbanka-3.radenkovic.rs/exchange
+    # (the partner appends /interbank, /negotiations, … onto it).
+    - matches:
+        - path: {type: PathPrefix, value: /exchange/interbank}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: {type: ReplacePrefixMatch, replacePrefixMatch: /interbank}
+      backendRefs:
+        - name: exchange-service
+          port: 8088
+    - matches:
+        - path: {type: PathPrefix, value: /exchange/public-stock}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: {type: ReplacePrefixMatch, replacePrefixMatch: /public-stock}
+      backendRefs:
+        - name: exchange-service
+          port: 8088
+    - matches:
+        - path: {type: PathPrefix, value: /exchange/negotiations}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: {type: ReplacePrefixMatch, replacePrefixMatch: /negotiations}
+      backendRefs:
+        - name: exchange-service
+          port: 8088
+    - matches:
+        - path: {type: PathPrefix, value: /exchange/user}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: {type: ReplacePrefixMatch, replacePrefixMatch: /user}
+      backendRefs:
+        - name: exchange-service
+          port: 8088
     # Frontend SPA + /config.js + static assets — catchall, no rewrite, kept last.
     - matches:
         - path: {type: PathPrefix, value: /}


### PR DESCRIPTION
Partner banks must reach our si-tx-proto endpoints, but the HTTPRoute only routed /<slug>/api -> service, so inbound protocol POSTs fell through to the frontend. Add /exchange/{interbank,public-stock,negotiations,user} rules that ReplacePrefixMatch back to the root paths exchange-service serves, per the professor mandate that every external URL is https://<domain>/<service-name>/... The working /exchange/api frontend rule is left untouched.

Also fix the PARTNER_BANKS_JSON example in app-secret.example.yaml: `code` was a quoted string (would crash NewRegistryFromJSON, RoutingNumber is an int) and baseUrl wrongly included a trailing /interbank (the client appends it).