### PR TITLE
feat: deploy notification-service to k8s

### DIFF
--- a/deploy/k8s/base/app-config.yaml
+++ b/deploy/k8s/base/app-config.yaml
@@ -29,6 +29,10 @@ data:
   # Cross-service HTTP — transfer-service → exchange-service. Internal call,
   # stays inside the cluster, never goes through the public Ingress.
   EXCHANGE_SERVICE_URL: http://exchange-service.exbanka-3.svc.cluster.local:8088
+  # Cross-service HTTP — emitters (exchange/account/loan/…) → notification-service.
+  # In-cluster call to the internal emit endpoint; never goes through the Ingress.
+  # Empty here would make notify.Client.Emit() a silent no-op.
+  NOTIFICATION_SERVICE_URL: http://notification-service.exbanka-3.svc.cluster.local:8090
   # Inter-bank protocol — this bank's 3-digit routing prefix.
   BANK_ROUTING_NUMBER: "333"
   # Frontend runtime config (consumed by the frontend container's entrypoint,

--- a/deploy/k8s/base/app-secret.example.yaml
+++ b/deploy/k8s/base/app-secret.example.yaml
@@ -17,6 +17,11 @@ stringData:
   # which the code never reads.
   ALPHA_VANTAGE_API_KEY: change-me
   REDIS_PASSWORD: change-me
+  # Shared secret for service-to-service notification emits. The emitting
+  # services send it in the X-Internal-Key header; notification-service requires
+  # it on POST /internal/v1/notifications. Both sides read the same key from this
+  # Secret, so they must match — set one real value here.
+  INTERNAL_API_KEY: change-me
   # PARTNER_BANKS_JSON is a JSON array of partner-bank entries. Contains per-
   # partner inbound/outbound API keys, so it lives in the Secret. Use "[]" for
   # no partners.

--- a/deploy/k8s/base/deployments.yaml
+++ b/deploy/k8s/base/deployments.yaml
@@ -599,6 +599,70 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: notification-service
+  namespace: exbanka-3
+  labels:
+    app.kubernetes.io/name: notification-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notification-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: notification-service
+        app.kubernetes.io/part-of: exbanka
+    spec:
+      containers:
+        - name: notification-service
+          image: ghcr.io/raf-si-2025/exbanka-3-notification-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8090
+          envFrom:
+            - configMapRef:
+                name: exbanka-app-config
+            - secretRef:
+                name: exbanka-app-secrets
+          env:
+            - name: HTTP_PORT
+              value: "8090"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-pguser-banking-service
+                  key: user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-pguser-banking-service
+                  key: password
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: frontend
   namespace: exbanka-3
   labels:

--- a/deploy/k8s/base/route.yaml
+++ b/deploy/k8s/base/route.yaml
@@ -159,6 +159,15 @@ spec:
       backendRefs:
         - name: exchange-service
           port: 8088
+    - matches:
+        - path: {type: PathPrefix, value: /notification/api}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: {type: ReplacePrefixMatch, replacePrefixMatch: /api}
+      backendRefs:
+        - name: notification-service
+          port: 8090
     # Frontend SPA + /config.js + static assets — catchall, no rewrite, kept last.
     - matches:
         - path: {type: PathPrefix, value: /}

--- a/deploy/k8s/base/services.yaml
+++ b/deploy/k8s/base/services.yaml
@@ -178,6 +178,23 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: notification-service
+  namespace: exbanka-3
+  labels:
+    app.kubernetes.io/name: notification-service
+    app.kubernetes.io/part-of: exbanka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: notification-service
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: frontend
   namespace: exbanka-3
   labels:


### PR DESCRIPTION
Add the notification-service Deployment (HTTP-only :8090, envFrom shared config+secret, DB creds via db-pguser-banking-service) and ClusterIP, plus a Gateway API HTTPRoute rule (/notification/api -> /api). Add NOTIFICATION_SERVICE_URL to app-config and document INTERNAL_API_KEY in the secret example so emitters and notification-service share the key.